### PR TITLE
Fix broken links.

### DIFF
--- a/cookie-policy.md
+++ b/cookie-policy.md
@@ -46,7 +46,7 @@ cookies. If you block cookies, you may not be able to use all the
 features on our website, or have a worse experience. We have gathered
 information about how you can block and delete cookies and local
 storage elements in this
-[FAQ article](https://support.whereby.com/article/187-how-do-i-block-or-delete-cookies).
+[FAQ article](https://support.whereby.com/article/353-policies).
 
 ## How we use cookies and local storage
 

--- a/privacy-policy.md
+++ b/privacy-policy.md
@@ -242,7 +242,7 @@ or services may be available, via the internet, around the world. We
 cannot prevent the use (or misuse) of such personal data by
 others. For information about what types of content you as a user is
 responsible, see this
-[FAQ article](https://support.whereby.com/article/188-what-types-of-content-am-i-as-a-user-responsible-for).
+[Terms of Service](https://whereby.com/information/tos/).
 
 
 We and our other group companies have offices and facilities in

--- a/terms-of-service.md
+++ b/terms-of-service.md
@@ -51,7 +51,7 @@ Whereby is for legitimate individual use only (personal or business
 communication). Your use of Whereby requires that you have hardware,
 software and an Internet connection fulfilling certain recommended
 requirements, as may be specified in
-[our FAQ](https://support.whereby.com/article/180-supported-devices-browsers).
+[our FAQ](https://support.whereby.com/article/318-supported-devices).
 If the recommended requirements are not met, you may potentially still
 use the Service, but normally with a lower quality or
 performance. Such reduced quality or performance will not give you the


### PR DESCRIPTION
After the whereby rename a new helpscout account needed to be created
and some of the articles have changed url.